### PR TITLE
Add mapping tests for Thyroid Panel

### DIFF
--- a/src/providers/antechV6-mapper.ts
+++ b/src/providers/antechV6-mapper.ts
@@ -157,9 +157,11 @@ export class AntechV6Mapper {
   }
 
   mapAntechV6UnitCodeResult(unitCodeResult: AntechV6UnitCodeResult, index: number): TestResult {
-    const testResultItems: TestResultItem[] = unitCodeResult.TestCodeResults?.map((testCodeResult, idx) =>
-      this.mapAntechV6TestCodeResult(testCodeResult, idx, unitCodeResult.OrderCode)
-    )
+    const testResultItems: TestResultItem[] =
+      unitCodeResult.TestCodeResults?.map((testCodeResult, idx) =>
+        this.mapAntechV6TestCodeResult(testCodeResult, idx, unitCodeResult.OrderCode)
+      ) ?? []
+
     return {
       seq: index,
       code: unitCodeResult.OrderCode ? unitCodeResult.OrderCode : unitCodeResult.UnitCodeExtID,
@@ -270,7 +272,9 @@ export class AntechV6Mapper {
   }
 
   private extractTestResults(unitCodeResults: AntechV6UnitCodeResult[]): TestResult[] {
-    return unitCodeResults.map(this.mapAntechV6UnitCodeResult, this)
+    return unitCodeResults
+      .filter((unitCodeResult) => unitCodeResult.TestCodeResults && unitCodeResult.TestCodeResults.length > 0)
+      .map(this.mapAntechV6UnitCodeResult, this)
   }
 
   private extractTestResultValueX(

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -19,7 +19,7 @@ import {
   AntechV6TestGuide,
   AntechV6UnitCodeResult
 } from '../interfaces/antechV6-api.interface'
-import { ServiceType, TestResult } from '@nominal-systems/dmi-engine-common/lib/interfaces/provider-service'
+import { ResultItem, ServiceType, TestResult } from '@nominal-systems/dmi-engine-common/lib/interfaces/provider-service'
 import * as path from 'path'
 import { DEFAULT_PET_SPECIES } from '../constants/default-pet-species'
 import { TEST_RESULT_SEQUENCING_MAP } from '../constants/test-result-sequencing-map.constant'
@@ -372,6 +372,11 @@ describe('AntechV6Mapper', () => {
     const cbcResultsResponse: any = FileUtils.loadFile(
       path.join(__dirname, '..', '..', 'test/api/LabResults/v6/GetAllResults/get-all-results_cbc.json')
     )
+
+    const tyroidResultsResponse: any = FileUtils.loadFile(
+      path.join(__dirname, '..', '..', 'test/api/LabResults/v6/GetAllResults/get-all-results_04.json')
+    )
+
     it('should map Antech order code results to DMI test results', () => {
       const unitCodeResult: AntechV6UnitCodeResult = allResultsResponseNew[0].UnitCodeResults[0]
       const testResult: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult, 0)
@@ -421,6 +426,48 @@ describe('AntechV6Mapper', () => {
           }
         }
       }
+    })
+
+    it('should correctly mapAntech Thyroid Panel unit code results', () => {
+      const unitCodeResult: AntechV6UnitCodeResult = tyroidResultsResponse[0].UnitCodeResults[0]
+      const testResult1: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult, 0)
+
+      const unitCodeResult2: AntechV6UnitCodeResult = tyroidResultsResponse[0].UnitCodeResults[1]
+      const testResult2: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult2, 0)
+
+      const unitCodeResult3: AntechV6UnitCodeResult = tyroidResultsResponse[0].UnitCodeResults[2]
+      const testResult3: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult3, 0)
+
+      const unitCodeResult4: AntechV6UnitCodeResult = tyroidResultsResponse[0].UnitCodeResults[3]
+      const testResult4: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult4, 0)
+      
+      expect(testResult1).toEqual({
+        seq: 0,
+        code: 'SA380',
+        name: '',
+        items: undefined
+      })
+      expect(testResult2).toMatchObject({
+        code: 'SA380',
+        name: 'TSH',
+        items: expect.arrayContaining([
+          expect.objectContaining({ name: 'TSH', code: '4001' })
+        ])
+      });
+      expect(testResult3).toMatchObject({
+        code: 'SA380',
+        name: 'Free T4 By Equilibrium Dialysis',
+        items: expect.arrayContaining([
+          expect.objectContaining({ name: 'Free T4 Equilibrium Dialysis', code: '6386' })
+        ])
+      });
+      expect(testResult4).toMatchObject({
+        code: 'SA380',
+        name: 'T4',
+        items: expect.arrayContaining([
+          expect.objectContaining({ name: 'T4', code: '4022' })
+        ]) 
+      });
     })
   })
 

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -19,7 +19,7 @@ import {
   AntechV6TestGuide,
   AntechV6UnitCodeResult
 } from '../interfaces/antechV6-api.interface'
-import { ResultItem, ServiceType, TestResult } from '@nominal-systems/dmi-engine-common/lib/interfaces/provider-service'
+import { ServiceType, TestResult } from '@nominal-systems/dmi-engine-common/lib/interfaces/provider-service'
 import * as path from 'path'
 import { DEFAULT_PET_SPECIES } from '../constants/default-pet-species'
 import { TEST_RESULT_SEQUENCING_MAP } from '../constants/test-result-sequencing-map.constant'

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -445,7 +445,7 @@ describe('AntechV6Mapper', () => {
         seq: 0,
         code: 'SA380',
         name: '',
-        items: undefined
+        items: expect.any(Array<TestResultItem>)
       })
       expect(testResult2).toMatchObject({
         code: 'SA380',
@@ -464,15 +464,19 @@ describe('AntechV6Mapper', () => {
       })
     })
 
-    it('should sort Antech Thyroid Panel in the order', () => {
+    it('should sort Antech Thyroid Panel in the order and ignore empty items', () => {
       for (const resultResponse of tyroidResultsResponse) {
         for (const unitCodeResult of resultResponse.UnitCodeResults) {
           const testResult: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult, 0)
-          expect(testResult.items).toHaveLength(unitCodeResult.TestCodeResults.length)
-          for (const [idx, item] of testResult.items.entries()) {
-            const indexInResponse = unitCodeResult.TestCodeResults.findIndex((r) => r.TestCodeExtID === item.code)
-            expect(item.seq).toBe(indexInResponse)
-            expect(idx).toBe(indexInResponse)
+          if (unitCodeResult.TestCodeResults && unitCodeResult.TestCodeResults.length > 0) {
+            expect(testResult.items).toHaveLength(unitCodeResult.TestCodeResults.length)
+            for (const [idx, item] of testResult.items.entries()) {
+              const indexInResponse = unitCodeResult.TestCodeResults.findIndex((r) => r.TestCodeExtID === item.code)
+              expect(item.seq).toBe(indexInResponse)
+              expect(idx).toBe(indexInResponse)
+            }
+          } else {
+            expect(testResult.items).toHaveLength(0)
           }
         }
       }

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -428,7 +428,7 @@ describe('AntechV6Mapper', () => {
       }
     })
 
-    it('should correctly mapAntech Thyroid Panel unit code results', () => {
+    it('should correctly map Antech Thyroid Panel unit code results', () => {
       const unitCodeResult: AntechV6UnitCodeResult = tyroidResultsResponse[0].UnitCodeResults[0]
       const testResult1: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult, 0)
 
@@ -462,6 +462,20 @@ describe('AntechV6Mapper', () => {
         name: 'T4',
         items: expect.arrayContaining([expect.objectContaining({ name: 'T4', code: '4022' })])
       })
+    })
+
+    it('should sort Antech Thyroid Panel in the order', () => {
+      for (const resultResponse of tyroidResultsResponse) {
+        for (const unitCodeResult of resultResponse.UnitCodeResults) {
+          const testResult: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult, 0)
+          expect(testResult.items).toHaveLength(unitCodeResult.TestCodeResults.length)
+          for (const [idx, item] of testResult.items.entries()) {
+            const indexInResponse = unitCodeResult.TestCodeResults.findIndex((r) => r.TestCodeExtID === item.code)
+            expect(item.seq).toBe(indexInResponse)
+            expect(idx).toBe(indexInResponse)
+          }
+        }
+      }
     })
   })
 

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -276,6 +276,10 @@ describe('AntechV6Mapper', () => {
       path.join(__dirname, '..', '..', 'test/api/LabResults/v6/GetAllResults/get-all-results_01.json')
     )
 
+    const tyroidResultsResponse: any = FileUtils.loadFile(
+      path.join(__dirname, '..', '..', 'test/api/LabResults/v6/GetAllResults/get-all-results_04.json')
+    )
+
     it('should map Antech results to DMI results', () => {
       const antechV6Result: AntechV6Result = allResultsResponse[0]
       const result: Result = mapper.mapAntechV6Result(antechV6Result)
@@ -357,6 +361,39 @@ describe('AntechV6Mapper', () => {
           }
         })
       )
+    })
+
+    it('should map Antech Tyroud Panel results to DMI results', () => {
+      const antechV6Result: AntechV6Result = tyroidResultsResponse[0]
+      const result: Result = mapper.mapAntechV6Result(antechV6Result)
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: '305580024',
+          orderId: '7092-VOY-37157652213',
+          accession: 'DLEA00533798',
+          status: ResultStatus.COMPLETED,
+          testResults: expect.any(Array<TestResult>)
+        })
+      )
+      expect(result.testResults.length).toBe(3)
+      expect(result.testResults[0]).toEqual({
+        seq: 0,
+        code: 'SA380',
+        name: 'TSH',
+        items: expect.arrayContaining([expect.objectContaining({ name: 'TSH', code: '4001' })])
+      })
+      expect(result.testResults[1]).toEqual({
+        seq: 1,
+        code: 'SA380',
+        name: 'Free T4 By Equilibrium Dialysis',
+        items: expect.arrayContaining([expect.objectContaining({ name: 'Free T4 Equilibrium Dialysis', code: '6386' })])
+      })
+      expect(result.testResults[2]).toEqual({
+        seq: 2,
+        code: 'SA380',
+        name: 'T4',
+        items: expect.arrayContaining([expect.objectContaining({ name: 'T4', code: '4022' })])
+      })
     })
   })
 

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -440,7 +440,7 @@ describe('AntechV6Mapper', () => {
 
       const unitCodeResult4: AntechV6UnitCodeResult = tyroidResultsResponse[0].UnitCodeResults[3]
       const testResult4: TestResult = mapper.mapAntechV6UnitCodeResult(unitCodeResult4, 0)
-      
+
       expect(testResult1).toEqual({
         seq: 0,
         code: 'SA380',
@@ -450,24 +450,18 @@ describe('AntechV6Mapper', () => {
       expect(testResult2).toMatchObject({
         code: 'SA380',
         name: 'TSH',
-        items: expect.arrayContaining([
-          expect.objectContaining({ name: 'TSH', code: '4001' })
-        ])
-      });
+        items: expect.arrayContaining([expect.objectContaining({ name: 'TSH', code: '4001' })])
+      })
       expect(testResult3).toMatchObject({
         code: 'SA380',
         name: 'Free T4 By Equilibrium Dialysis',
-        items: expect.arrayContaining([
-          expect.objectContaining({ name: 'Free T4 Equilibrium Dialysis', code: '6386' })
-        ])
-      });
+        items: expect.arrayContaining([expect.objectContaining({ name: 'Free T4 Equilibrium Dialysis', code: '6386' })])
+      })
       expect(testResult4).toMatchObject({
         code: 'SA380',
         name: 'T4',
-        items: expect.arrayContaining([
-          expect.objectContaining({ name: 'T4', code: '4022' })
-        ]) 
-      });
+        items: expect.arrayContaining([expect.objectContaining({ name: 'T4', code: '4022' })])
+      })
     })
   })
 

--- a/test/api/LabResults/v6/GetAllResults/get-all-results_04.json
+++ b/test/api/LabResults/v6/GetAllResults/get-all-results_04.json
@@ -1,0 +1,169 @@
+[
+  {
+  "Client": {
+    "Id": "HOU0JUG",
+    "FirstName": "Eric",
+    "LastName": "Patterson"
+  },
+  "Clinic": {
+    "ClinicID": 7092,
+    "LabId": 1,
+    "ClinicExtId": "12877",
+    "HasUsers": false
+  },
+  "ClinicAccessionID": "7092-VOY-37157652213",
+  "Corrected": "",
+  "CorrectedTestCount": 0,
+  "Doctor": {
+    "Id": "409479",
+    "FirstName": "Brian",
+    "LastName": "Wright"
+  },
+  "ID": 305580024,
+  "LabAccessionID": "DLEA00533798",
+  "LatestAccessionUpdate": "2025-01-21T14:53:00",
+  "OrderStatus": "Final",
+  "PendingTestCount": 0,
+  "Pet": {
+    "Id": "13581060946",
+    "Name": "Phil"
+  },
+  "ProfileDisplay": "Thyroid Profile 3",
+  "ReceivedDateTime": "2025-01-18T23:07:00",
+  "ReleasedDateTime": "0001-01-01T00:00:00",
+  "TestDescription": "Thyroid Profile 3 ,TSH,Free T4 By Equilibrium Dialysis,T4",
+  "TotalTestCount": 4,
+  "ViewedDateTime": "0001-01-01T00:00:00",
+  "UnitCodeResults": [
+    {
+      "UnitCodeResultID": "877067834",
+      "UnitCodeID": 0,
+      "ProfileExtID": "530399",
+      "UnitCodeExtID": "",
+      "ReleasedDateTime": "0001-01-01T00:00:00",
+      "ViewedDateTime": "0001-01-01T00:00:00",
+      "ResultStatus": "F",
+      "OrderControlStatus": "NW",
+      "OrderCode": "SA380",
+      "UnitCodeDisplayName": "",
+      "ProfileDisplayName": "Thyroid Profile 3",
+      "UnitCodeType": "",
+      "AnalyzerName": "",
+      "UCType": "",
+      "Category": "",
+      "AccessionResultID": 305580024
+    },
+    {
+      "UnitCodeResultID": "877067837",
+      "UnitCodeID": 12218,
+      "ProfileExtID": "530399",
+      "UnitCodeExtID": "502529",
+      "ReleasedDateTime": "2025-01-19T00:55:00",
+      "ViewedDateTime": "0001-01-01T00:00:00",
+      "ResultStatus": "F",
+      "OrderControlStatus": "RE",
+      "OrderCode": "SA380",
+      "UnitCodeDisplayName": "TSH",
+      "ProfileDisplayName": "Thyroid Profile 3",
+      "UnitCodeType": "",
+      "AnalyzerName": "",
+      "UCType": "",
+      "TestCodeResults": [
+        {
+        "TestCodeID": "2459",
+        "TestCodeResultID": "8659447583",
+        "AbnormalFlag": "",
+        "Result": "0.17",
+        "Range": "0 - 0.60",
+        "TestCodeExtID": "4001",
+        "Test": "TSH",
+        "Unit": "NG/ML",
+        "Comments": "  While many dogs with primary hypothyroidism have elevated cTSH concentrations, up to one third of affected dogs have normal or low cTSH concentrations, for reasons that are unclear. In those cases where TSH concentrations are normal and hypothyroidism is still strongly suspected, consider performing a free T4 and/or thyroglobulin autoantibodies.",
+        "Min": "",
+        "Max": "",
+        "TestType": "",
+        "UnitCodeID": "877067837",
+        "Displayorder": "ng/mL",
+        "SortOrder": ""
+        }
+      ],
+      "Category": "Endocrinology",
+      "AccessionResultID": 305580024
+    },
+    {
+      "UnitCodeResultID": "877067836",
+      "UnitCodeID": 12204,
+      "ProfileExtID": "530399",
+      "UnitCodeExtID": "502473",
+      "ReleasedDateTime": "2025-01-21T13:48:00",
+      "ViewedDateTime": "0001-01-01T00:00:00",
+      "ResultStatus": "F",
+      "OrderControlStatus": "RE",
+      "OrderCode": "SA380",
+      "UnitCodeDisplayName": "Free T4 By Equilibrium Dialysis",
+      "ProfileDisplayName": "Thyroid Profile 3",
+      "UnitCodeType": "",
+      "AnalyzerName": "",
+      "UCType": "",
+      "TestCodeResults": [
+        {
+        "TestCodeID": "3182",
+        "TestCodeResultID": "8664018239",
+        "AbnormalFlag": "",
+        "Result": "19.8",
+        "Range": "8-40",
+        "TestCodeExtID": "6386",
+        "Test": "Free T4 Equilibrium Dialysis",
+        "Unit": "PMOL/L",
+        "Comments": "",
+        "Min": "2.0",
+        "Max": "125.0",
+        "TestType": "",
+        "UnitCodeID": "877067836",
+        "Displayorder": "pmol/L",
+        "SortOrder": ""
+        }
+      ],
+      "Category": "Endocrinology",
+      "AccessionResultID": 305580024
+    },
+    {
+      "UnitCodeResultID": "877067835",
+      "UnitCodeID": 12211,
+      "ProfileExtID": "530399",
+      "UnitCodeExtID": "502511",
+      "ReleasedDateTime": "2025-01-19T03:39:00",
+      "ViewedDateTime": "0001-01-01T00:00:00",
+      "ResultStatus": "F",
+      "OrderControlStatus": "RE",
+      "OrderCode": "SA380",
+      "UnitCodeDisplayName": "T4",
+      "ProfileDisplayName": "Thyroid Profile 3",
+      "UnitCodeType": "",
+      "AnalyzerName": "",
+      "UCType": "",
+      "TestCodeResults": [
+        {
+        "TestCodeID": "2496",
+        "TestCodeResultID": "8659769729",
+        "AbnormalFlag": "",
+        "Result": "1.4",
+        "Range": "0.8-3.5",
+        "TestCodeExtID": "4022",
+        "Test": "T4",
+        "Unit": "UG/DL",
+        "Comments": "",
+        "Min": "0.1",
+        "Max": "12",
+        "TestType": "",
+        "UnitCodeID": "877067835",
+        "Displayorder": "<font face=\"symbol\">&#109;</font>g/dL",
+        "SortOrder": ""
+        }
+      ],
+      "Category": "Endocrinology",
+      "AccessionResultID": 305580024
+    }
+  ]
+  }
+]


### PR DESCRIPTION
I added tests, and it seems to be mapping correctly.

We should keep investigating the issue (dmi-api?) until we find the root cause and can reproduce it.

Now that we know those tests (the empty ones) only serve as labels and don’t provide any useful information for us, should we ignore them? If so, we could try that and see if it solves the issue.