### PR TITLE
Refactor order submission logic to conditionally allow auto submitting orders

### DIFF
--- a/src/interfaces/antechV6-message-data.interface.ts
+++ b/src/interfaces/antechV6-message-data.interface.ts
@@ -18,4 +18,5 @@ export interface AntechV6IntegrationOptions {
   password: string
   clinicId: string
   labId: string
+  autoSubmitEnabled?: boolean
 }

--- a/src/services/antechV6.service.spec.ts
+++ b/src/services/antechV6.service.spec.ts
@@ -403,7 +403,124 @@ describe('AntechV6Service', () => {
       )
     })
 
-    it('places order when autoSubmitOrder is true', async () => {
+    it('places a pre-order when autoSubmitEnabled is true in integrationOptions and autoSubmitOrder is empty in metadata', async () => {
+      antechV6ApiServiceMock.placeOrder.mockResolvedValue({
+        payload: 'ok',
+        status: 200,
+        message: 'success',
+        isSuccess: true,
+        requestId: 'r1',
+        Token: 'tok',
+      })
+      const resp: OrderCreatedResponse = await service.createOrder(createOrderPayload, {
+        ...metadataMock,
+        integrationOptions: {
+          ...metadataMock.integrationOptions,
+          autoSubmitEnabled: true,
+        },
+      } as any)
+
+      expect(antechV6ApiServiceMock.placeOrder).not.toHaveBeenCalled()
+      expect(antechV6ApiServiceMock.placePreOrder).toHaveBeenCalled()
+      expect(resp).toEqual(
+        expect.objectContaining({
+          requisitionId: 'REQ123',
+          externalId: 'REQ123',
+          status: OrderStatus.WAITING_FOR_INPUT,
+        }),
+      )
+    })
+
+    it('places an order when autoSubmitEnabled is true in integrationOptions autoSubmitOrder is true in metadata', async () => {
+      antechV6ApiServiceMock.placeOrder.mockResolvedValue({
+        payload: 'ok',
+        status: 200,
+        message: 'success',
+        isSuccess: true,
+        requestId: 'r1',
+        Token: 'tok',
+      })
+      const resp: OrderCreatedResponse = await service.createOrder(createOrderPayload, {
+        ...metadataMock,
+        autoSubmitOrder: true,
+        integrationOptions: {
+          ...metadataMock.integrationOptions,
+          autoSubmitEnabled: true,
+        },
+      } as any)
+
+      expect(antechV6ApiServiceMock.placeOrder).toHaveBeenCalled()
+      expect(antechV6ApiServiceMock.placePreOrder).not.toHaveBeenCalled()
+      expect(resp).toEqual(
+        expect.objectContaining({
+          requisitionId: 'REQ123',
+          externalId: 'REQ123',
+          status: OrderStatus.SUBMITTED,
+        }),
+      )
+      // No submission URI on auto-submitted orders
+      expect((resp as any).submissionUri).toBeUndefined()
+    })
+
+    it('places a pre-order when autoSubmitEnabled is true in integrationOptions and autoSubmitOrder is false in metadata', async () => {
+      antechV6ApiServiceMock.placeOrder.mockResolvedValue({
+        payload: 'ok',
+        status: 200,
+        message: 'success',
+        isSuccess: true,
+        requestId: 'r1',
+        Token: 'tok',
+      })
+      const resp: OrderCreatedResponse = await service.createOrder(createOrderPayload, {
+        ...metadataMock,
+        autoSubmitOrder: false,
+        integrationOptions: {
+          ...metadataMock.integrationOptions,
+          autoSubmitEnabled: true,
+        },
+      } as any)
+
+      expect(antechV6ApiServiceMock.placeOrder).not.toHaveBeenCalled()
+      expect(antechV6ApiServiceMock.placePreOrder).toHaveBeenCalled()
+      expect(resp).toEqual(
+        expect.objectContaining({
+          requisitionId: 'REQ123',
+          externalId: 'REQ123',
+          status: OrderStatus.WAITING_FOR_INPUT,
+        }),
+      )
+    })
+
+    it('places a pre-order when autoSubmitEnabled is false in integrationOptions and autoSubmitOrder is true in metadata', async () => {
+      antechV6ApiServiceMock.placeOrder.mockResolvedValue({
+        payload: 'ok',
+        status: 200,
+        message: 'success',
+        isSuccess: true,
+        requestId: 'r1',
+        Token: 'tok',
+      })
+      const resp: OrderCreatedResponse = await service.createOrder(createOrderPayload, {
+        ...metadataMock,
+        autoSubmitOrder: true,
+        integrationOptions: {
+          ...metadataMock.integrationOptions,
+          autoSubmitEnabled: false,
+        },
+      } as any)
+
+      expect(antechV6ApiServiceMock.placeOrder).not.toHaveBeenCalled()
+      expect(antechV6ApiServiceMock.placePreOrder).toHaveBeenCalled()
+      expect(resp).toEqual(
+        expect.objectContaining({
+          requisitionId: 'REQ123',
+          externalId: 'REQ123',
+          status: OrderStatus.WAITING_FOR_INPUT,
+        }),
+      )
+    })
+
+    it('places a pre-order when autoSubmitEnabled is empty in integrationOptions and autoSubmitOrder is true in metadata', async () => {
       antechV6ApiServiceMock.placeOrder.mockResolvedValue({
         payload: 'ok',
         status: 200,
@@ -416,17 +533,16 @@ describe('AntechV6Service', () => {
         ...metadataMock,
         autoSubmitOrder: true,
       } as any)
-      expect(antechV6ApiServiceMock.placeOrder).toHaveBeenCalled()
-      expect(antechV6ApiServiceMock.placePreOrder).not.toHaveBeenCalled()
+
+      expect(antechV6ApiServiceMock.placeOrder).not.toHaveBeenCalled()
+      expect(antechV6ApiServiceMock.placePreOrder).toHaveBeenCalled()
       expect(resp).toEqual(
         expect.objectContaining({
           requisitionId: 'REQ123',
           externalId: 'REQ123',
-          status: OrderStatus.SUBMITTED,
+          status: OrderStatus.WAITING_FOR_INPUT,
         }),
       )
-      // No submission URI on auto-submitted orders
-      expect((resp as any).submissionUri).toBeUndefined()
     })
   })
 

--- a/src/services/antechV6.service.ts
+++ b/src/services/antechV6.service.ts
@@ -84,15 +84,18 @@ export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
 
     const orderPayload = this.antechV6Mapper.mapCreateOrderPayload(payload, metadata)
 
-    // Disabling auto submission of orders for now
-    // if (metadata.autoSubmitOrder === true) {
-    //   await this.antechV6Api.placeOrder(
-    //     metadata.providerConfiguration.baseUrl,
-    //     credentials,
-    //     orderPayload as AntechV6Order,
-    //   )
-    //   return this.antechV6Mapper.mapAntechV6Order(orderPayload)
-    // }
+    // Allow autoSubmitOrder only if the integration option is enabled
+    const autoSubmitEnabled = metadata.integrationOptions?.autoSubmitEnabled ?? false
+    const autoSubmitOrder = metadata.autoSubmitOrder === true && autoSubmitEnabled === true
+
+    if (autoSubmitOrder === true) {
+      await this.antechV6Api.placeOrder(
+        metadata.providerConfiguration.baseUrl,
+        credentials,
+        orderPayload as AntechV6Order,
+      )
+      return this.antechV6Mapper.mapAntechV6Order(orderPayload)
+    }
 
     const preOrderPlacement: AntechV6PreOrderPlacement & AntechV6AccessToken =
       await this.antechV6Api.placePreOrder(


### PR DESCRIPTION
This pull request introduces support for a new `autoSubmitEnabled` integration option to control whether orders can be automatically submitted in the Antech V6 integration. The logic for order submission has been updated to require both `autoSubmitEnabled` and `autoSubmitOrder` to be true before placing an order, otherwise a pre-order is placed. Comprehensive tests have been added to cover all combinations of these flags.

**Integration options and service logic:**

* Added an optional `autoSubmitEnabled` property to the `AntechV6IntegrationOptions` interface to allow configuration of auto-submission behavior.
* Updated `AntechV6Service.createOrder` to only place an order if both `integrationOptions.autoSubmitEnabled` and `autoSubmitOrder` are true; otherwise, a pre-order is placed.

**Testing enhancements:**

* Added and updated tests in `antechV6.service.spec.ts` to verify the new logic for all combinations of `autoSubmitEnabled` and `autoSubmitOrder`, ensuring correct behavior for placing orders and pre-orders. [[1]](diffhunk://#diff-fccfb3d45c72450476e871043aaa6b63d07509e3b3f5d7cc0f27e37ad4ad7b45L406-R434) [[2]](diffhunk://#diff-fccfb3d45c72450476e871043aaa6b63d07509e3b3f5d7cc0f27e37ad4ad7b45R446-R451) [[3]](diffhunk://#diff-fccfb3d45c72450476e871043aaa6b63d07509e3b3f5d7cc0f27e37ad4ad7b45R464-R546)…n based on integration options