### PR TITLE
Scope RpcExceptionFilter to AntechV6Controller

### DIFF
--- a/src/antechV6.module.ts
+++ b/src/antechV6.module.ts
@@ -9,8 +9,6 @@ import { AntechV6Controller } from './controllers/antechV6.controller'
 import { AntechV6Mapper } from './providers/antechV6-mapper'
 import { ClientsModule, Transport } from '@nestjs/microservices'
 import { AntechV6ApiModule } from './antechV6-api/antech-v6-api.module'
-import { APP_FILTER } from '@nestjs/core'
-import { RpcExceptionFilter } from './filters/rcp-exception.filter'
 import { StatsigFeatureFlagProvider } from './feature-flags/statsig-feature-flag.provider'
 import { FEATURE_FLAG_PROVIDER } from './feature-flags/feature-flag.interface'
 
@@ -44,10 +42,6 @@ import { FEATURE_FLAG_PROVIDER } from './feature-flags/feature-flag.interface'
     AntechV6ApiService,
     AntechV6OrdersProcessor,
     AntechV6ResultsProcessor,
-    {
-      provide: APP_FILTER,
-      useClass: RpcExceptionFilter,
-    },
   ],
   controllers: [AntechV6Controller],
   exports: [BullModule],

--- a/src/controllers/antechV6.controller.ts
+++ b/src/controllers/antechV6.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Logger } from '@nestjs/common'
+import { Controller, Logger, UseFilters } from '@nestjs/common'
 import {
   ApiEvent,
   Breed,
@@ -23,8 +23,10 @@ import { MessagePattern } from '@nestjs/microservices'
 import { AntechV6MessageData } from '../interfaces/antechV6-message-data.interface'
 import { PROVIDER_NAME } from '../constants/provider-name.constant'
 import { AntechV6Service } from '../services/antechV6.service'
+import { RpcExceptionFilter } from '../filters/rcp-exception.filter'
 
 @Controller('engine/antech-v6')
+@UseFilters(RpcExceptionFilter)
 export class AntechV6Controller
   implements
     ProviderOrderCreation,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
  - Moves `RpcExceptionFilter` from a global module-level filter (`APP_FILTER`) to a controller-scoped `@UseFilters()` decorator on `AntechV6Controller`                                                        
  - Ensures the filter only applies where it's needed rather than globally across the module                                                                                                                    
  - This prevents the filter from interfering with exception handling in other providers registered within the same application (e.g., other integration modules loaded by `dmi-engine`)                 
