### PR TITLE
Skip placeholder results with no tests yet

### DIFF
--- a/src/common/utils/mapper-utils.spec.ts
+++ b/src/common/utils/mapper-utils.spec.ts
@@ -1,7 +1,8 @@
-import { extractPetAge, extractPetWeight } from './mapper-utils'
+import { extractPetAge, extractPetWeight, isPlaceholderResult } from './mapper-utils'
 import { DEFAULT_PET_AGE } from '../../constants/default-pet-age'
 import * as moment from 'moment'
 import { OrderPatient } from '@nominal-systems/dmi-engine-common'
+import { AntechV6Result } from '../../interfaces/antechV6-api.interface'
 
 describe('MapperUtils', () => {
   describe('extractPetAge()', () => {
@@ -144,6 +145,37 @@ describe('MapperUtils', () => {
         weightUnits: 'kg',
       }
       expect(extractPetWeight(patient as OrderPatient)).toEqual({})
+    })
+  })
+
+  describe('isPlaceholderResult()', () => {
+    it('returns true when TotalTestCount is 0 and UnitCodeResults is empty', () => {
+      const result = {
+        TotalTestCount: 0,
+        UnitCodeResults: [],
+      } as unknown as AntechV6Result
+      expect(isPlaceholderResult(result)).toBe(true)
+    })
+
+    it('returns true when TotalTestCount and UnitCodeResults are missing', () => {
+      const result = {} as unknown as AntechV6Result
+      expect(isPlaceholderResult(result)).toBe(true)
+    })
+
+    it('returns false when TotalTestCount is greater than 0', () => {
+      const result = {
+        TotalTestCount: 2,
+        UnitCodeResults: [],
+      } as unknown as AntechV6Result
+      expect(isPlaceholderResult(result)).toBe(false)
+    })
+
+    it('returns false when UnitCodeResults is non-empty', () => {
+      const result = {
+        TotalTestCount: 0,
+        UnitCodeResults: [{ OrderCode: 'X' }],
+      } as unknown as AntechV6Result
+      expect(isPlaceholderResult(result)).toBe(false)
     })
   })
 })

--- a/src/common/utils/mapper-utils.ts
+++ b/src/common/utils/mapper-utils.ts
@@ -140,6 +140,12 @@ export function isOrphanResult(result: AntechV6Result): boolean {
   return isNullOrUndefinedOrEmpty(result.ClinicAccessionID)
 }
 
+export function isPlaceholderResult(result: AntechV6Result): boolean {
+  const totalTestCount = result.TotalTestCount ?? 0
+  const unitCodeResultsCount = result.UnitCodeResults?.length ?? 0
+  return totalTestCount === 0 && unitCodeResultsCount === 0
+}
+
 export function extractPatientFromResult(result: AntechV6Result): Patient {
   return {
     name: result.Pet.Name || '',

--- a/src/providers/antechV6-mapper.ts
+++ b/src/providers/antechV6-mapper.ts
@@ -52,6 +52,7 @@ import {
   extractVeterinarianFromResult,
   generateClinicAccessionId,
   isOrphanResult,
+  isPlaceholderResult,
   mapPatientSex,
   mapTestCodeResultStatus,
 } from '../common/utils/mapper-utils'
@@ -306,6 +307,14 @@ export class AntechV6Mapper {
     let resultTotalCount = result.TotalTestCount ?? 0
     const status = ResultStatus.PENDING
 
+    if (result.Corrected !== undefined && result.Corrected !== '') {
+      return ResultStatus.REVISED
+    }
+
+    if (isPlaceholderResult(result)) {
+      return ResultStatus.PENDING
+    }
+
     // Filter out completed tests without results
     const filteredUnitCodeResults =
       result.UnitCodeResults?.filter(
@@ -315,10 +324,6 @@ export class AntechV6Mapper {
       ) ?? []
 
     resultTotalCount -= filteredUnitCodeResults.length
-
-    if (result.Corrected !== undefined && result.Corrected !== '') {
-      return ResultStatus.REVISED
-    }
 
     if (resultPendingCount > 0 && resultPendingCount < resultTotalCount) {
       return ResultStatus.PARTIAL

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -1082,17 +1082,22 @@ describe('AntechV6Mapper', () => {
       expect(mapper.extractResultStatus(result)).toBe(ResultStatus.COMPLETED)
     })
 
-    it('should return COMPLETED if TotalTestCount is 0', () => {
-      const result: AntechV6Result = { PendingTestCount: 0, TotalTestCount: 0 } as AntechV6Result
-      expect(mapper.extractResultStatus(result)).toBe(ResultStatus.COMPLETED)
+    it('should return PENDING for a placeholder result with TotalTestCount=0 and empty UnitCodeResults', () => {
+      const result: AntechV6Result = {
+        PendingTestCount: 0,
+        TotalTestCount: 0,
+        UnitCodeResults: [],
+      } as unknown as AntechV6Result
+      expect(mapper.extractResultStatus(result)).toBe(ResultStatus.PENDING)
     })
 
     it('should handle undefined PendingTestCount and TotalTestCount safely', () => {
       const result: AntechV6Result = {
         PendingTestCount: undefined,
         TotalTestCount: undefined,
-      } as AntechV6Result
-      expect(mapper.extractResultStatus(result)).toBe(ResultStatus.COMPLETED)
+        UnitCodeResults: [],
+      } as unknown as AntechV6Result
+      expect(mapper.extractResultStatus(result)).toBe(ResultStatus.PENDING)
 
       const result_1: AntechV6Result = {
         PendingTestCount: undefined,

--- a/src/services/antechV6.service.spec.ts
+++ b/src/services/antechV6.service.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@nominal-systems/dmi-engine-common'
 import { AntechV6ApiService } from '../antechV6-api/antechV6-api.service'
 import { AntechV6Mapper } from '../providers/antechV6-mapper'
-import { AntechV6OrderStatus } from '../interfaces/antechV6-api.interface'
+import { AntechV6OrderStatus, AntechV6Result } from '../interfaces/antechV6-api.interface'
 
 describe('AntechV6Service', () => {
   let service: AntechV6Service
@@ -33,6 +33,7 @@ describe('AntechV6Service', () => {
   const antechV6ApiServiceMock = {
     getOrderStatus: jest.fn(),
     getResultStatus: jest.fn(),
+    getAllResults: jest.fn(),
     placePreOrder: jest.fn(),
     placeOrder: jest.fn(),
     getTestGuide: jest.fn(),
@@ -652,6 +653,65 @@ describe('AntechV6Service', () => {
             },
           ],
           hash: expect.any(String),
+        }),
+      )
+    })
+  })
+
+  describe('getBatchResults()', () => {
+    const payloadMock = {
+      integrationId: 'integration-id',
+    } as unknown as NullPayloadPayload
+
+    it('should filter out placeholder results with no tests yet', async () => {
+      const placeholder: Partial<AntechV6Result> = {
+        ID: 329199547,
+        ClinicAccessionID: '13476-VOY-7054486890',
+        LabAccessionID: 'NYEA02240122',
+        OrderStatus: AntechV6OrderStatus.Partial,
+        PendingTestCount: 0,
+        TotalTestCount: 0,
+        CorrectedTestCount: 0,
+        Corrected: '',
+        UnitCodeResults: [],
+      }
+      antechV6ApiServiceMock.getAllResults.mockResolvedValue([placeholder])
+
+      const response = await service.getBatchResults(payloadMock, metadataMock)
+
+      expect(response.results).toEqual([])
+    })
+
+    it('should map results that have content', async () => {
+      const result: Partial<AntechV6Result> = {
+        ID: 1,
+        ClinicAccessionID: 'ACC-1',
+        LabAccessionID: 'LAB-1',
+        OrderStatus: AntechV6OrderStatus.Final,
+        PendingTestCount: 0,
+        TotalTestCount: 1,
+        Corrected: '',
+        UnitCodeResults: [
+          {
+            UnitCodeExtID: 'UC1',
+            OrderCode: 'OC1',
+            UnitCodeDisplayName: 'Unit 1',
+            ProfileDisplayName: 'Profile 1',
+            TestCodeResults: [],
+            ResultStatus: 'F',
+          },
+        ] as any,
+      }
+      antechV6ApiServiceMock.getAllResults.mockResolvedValue([result])
+
+      const response = await service.getBatchResults(payloadMock, metadataMock)
+
+      expect(response.results).toHaveLength(1)
+      expect(response.results[0]).toEqual(
+        expect.objectContaining({
+          id: '1',
+          orderId: 'ACC-1',
+          accession: 'LAB-1',
         }),
       )
     })

--- a/src/services/antechV6.service.ts
+++ b/src/services/antechV6.service.ts
@@ -36,6 +36,7 @@ import {
 } from '../interfaces/antechV6-api.interface'
 import { AntechV6Mapper } from '../providers/antechV6-mapper'
 import { AntechV6ApiException } from '../common/exceptions/antechV6-api.exception'
+import { isPlaceholderResult } from '../common/utils/mapper-utils'
 
 @Injectable()
 export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
@@ -201,8 +202,18 @@ export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
       },
     }
 
+    const resultsWithContent = allResults.filter((result) => {
+      if (isPlaceholderResult(result)) {
+        this.logger.debug(
+          `Skipping placeholder result LabAccessionID=${result.LabAccessionID} ClinicAccessionID=${result.ClinicAccessionID} (no tests yet)`,
+        )
+        return false
+      }
+      return true
+    })
+
     return {
-      results: allResults.map((result) =>
+      results: resultsWithContent.map((result) =>
         this.antechV6Mapper.mapAntechV6Result(result, featureFlagContext),
       ),
     }


### PR DESCRIPTION
## Summary

- Filter out Antech "placeholder" results (`TotalTestCount=0` and empty `UnitCodeResults`) in `getBatchResults` so they are not emitted to `external_results`/`external_order_results` and not acknowledged back to Antech.
- Defensively map the same shape to `PENDING` in `AntechV6Mapper.extractResultStatus` (REVISED still takes precedence).
- Add `isPlaceholderResult` helper alongside `isOrphanResult`.

Closes #57.

## Test plan

- [x] `npm test` (90/90 passing)
- [x] `npx eslint 'src/**/*.ts'`
- [x] `npm run build`
- [ ] Verify in a real environment that a placeholder result from Antech is no longer acked and the eventual completed result is processed normally.