### PR TITLE
Propagate integration context for external request tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nominal-systems/dmi-engine-antech-v6-integration",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nominal-systems/dmi-engine-antech-v6-integration",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",
@@ -16,7 +16,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/microservices": "^10.3.3",
         "@nestjs/platform-express": "^10.0.0",
-        "@nominal-systems/dmi-engine-common": "^1.2.0",
+        "@nominal-systems/dmi-engine-common": "^1.3.0",
         "axios": "^1.6.7",
         "bull": "^4.12.2",
         "class-transformer": "^0.5.1",
@@ -2099,9 +2099,9 @@
       }
     },
     "node_modules/@nominal-systems/dmi-engine-common": {
-      "version": "1.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.2.0/970a29d5c0a119a903ff77cef49ba9e0a28ebbf2",
-      "integrity": "sha512-u+fZ6IvVWE2Ri92pVZ8ZZGuRIELJSFP0IezDSShcMUBWAn26hLFefhBcYEHG4DGnTu2do4nU3WLASZs8uRCSkw==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.3.0/acfea5ef01c6eacd6fb2cb89f7c424bd3c57817b",
+      "integrity": "sha512-c0KHPdYRz0bdGS3E1qPlXEPmHnlpFCHKA2MRx6lq1Xd//qHCl+Yd7gEtGsE0g5/UuWyDEY0iuzLhigHNYTmucw==",
       "license": "ISC",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nominal-systems/dmi-engine-antech-v6-integration",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "",
   "author": "",
   "license": "UNLICENSED",
@@ -33,7 +33,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.3.3",
     "@nestjs/platform-express": "^10.0.0",
-    "@nominal-systems/dmi-engine-common": "^1.2.0",
+    "@nominal-systems/dmi-engine-common": "^1.3.0",
     "axios": "^1.6.7",
     "bull": "^4.12.2",
     "class-transformer": "^0.5.1",

--- a/src/antechV6.module.ts
+++ b/src/antechV6.module.ts
@@ -1,5 +1,7 @@
 import { BullModule } from '@nestjs/bull'
 import { AntechV6OrdersProcessor } from './processors/antechV6-orders.processor'
+import { APP_INTERCEPTOR } from '@nestjs/core'
+import { IntegrationContextInterceptor } from '@nominal-systems/dmi-engine-common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { AntechV6Service } from './services/antechV6.service'
 import { AntechV6ApiService } from './antechV6-api/antechV6-api.service'
@@ -42,6 +44,10 @@ import { FEATURE_FLAG_PROVIDER } from './feature-flags/feature-flag.interface'
     AntechV6ApiService,
     AntechV6OrdersProcessor,
     AntechV6ResultsProcessor,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: IntegrationContextInterceptor,
+    },
   ],
   controllers: [AntechV6Controller],
   exports: [BullModule],

--- a/src/processors/antechV6-orders.processor.ts
+++ b/src/processors/antechV6-orders.processor.ts
@@ -1,5 +1,6 @@
 import { Process, Processor } from '@nestjs/bull'
 import { Job } from 'bull'
+import { runWithRequestContext } from '@nominal-systems/dmi-engine-common'
 import { AntechV6MessageData } from '../interfaces/antechV6-message-data.interface'
 import { Inject, Logger } from '@nestjs/common'
 import { PROVIDER_NAME } from '../constants/provider-name.constant'
@@ -18,31 +19,33 @@ export class AntechV6OrdersProcessor {
   @Process()
   async fetchOrders(job: Job<AntechV6MessageData>) {
     const { payload, ...metadata } = job.data
-    this.logger.debug(`Fetching orders for integration ${payload.integrationId}`)
-    try {
-      const orders = await this.antechV6Service.getBatchOrders(payload, metadata)
+    await runWithRequestContext({ integrationId: payload.integrationId }, async () => {
+      this.logger.debug(`Fetching orders for integration ${payload.integrationId}`)
+      try {
+        const orders = await this.antechV6Service.getBatchOrders(payload, metadata)
 
-      if (orders.length > 0) {
-        this.logger.log(
-          `Fetched ${orders.length} order${orders.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
-        )
+        if (orders.length > 0) {
+          this.logger.log(
+            `Fetched ${orders.length} order${orders.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
+          )
 
-        const clinicAccessionIds = orders
-          .map((order) => order.externalId)
-          .filter((accId): accId is string => accId !== undefined)
+          const clinicAccessionIds = orders
+            .map((order) => order.externalId)
+            .filter((accId): accId is string => accId !== undefined)
 
-        this.apiClient.emit('external_orders', {
-          integrationId: payload.integrationId,
-          orders,
-        })
+          this.apiClient.emit('external_orders', {
+            integrationId: payload.integrationId,
+            orders,
+          })
 
-        await this.antechV6Service.acknowledgeOrders({ ids: clinicAccessionIds }, metadata)
-        this.logger.log(
-          `Acknowledged orders ${clinicAccessionIds.join(',')} for integration ${payload.integrationId}`,
-        )
+          await this.antechV6Service.acknowledgeOrders({ ids: clinicAccessionIds }, metadata)
+          this.logger.log(
+            `Acknowledged orders ${clinicAccessionIds.join(',')} for integration ${payload.integrationId}`,
+          )
+        }
+      } catch (error) {
+        this.logger.error(`Error fetching orders for integration ${payload.integrationId}`)
       }
-    } catch (error) {
-      this.logger.error(`Error fetching orders for integration ${payload.integrationId}`)
-    }
+    })
   }
 }

--- a/src/processors/antechV6-results.processor.ts
+++ b/src/processors/antechV6-results.processor.ts
@@ -2,6 +2,7 @@ import { Inject, Logger } from '@nestjs/common'
 import { PROVIDER_NAME } from '../constants/provider-name.constant'
 import { Process, Processor } from '@nestjs/bull'
 import { Job } from 'bull'
+import { runWithRequestContext } from '@nominal-systems/dmi-engine-common'
 import { AntechV6MessageData } from '../interfaces/antechV6-message-data.interface'
 import { AntechV6Service } from '../services/antechV6.service'
 import { ClientProxy } from '@nestjs/microservices'
@@ -18,37 +19,39 @@ export class AntechV6ResultsProcessor {
   @Process()
   async fetchResults(job: Job<AntechV6MessageData>) {
     const { payload, ...metadata } = job.data
-    this.logger.debug(`Fetching results for integration ${payload.integrationId}`)
-    try {
-      const batchResults = await this.antechV6Service.getBatchResults(payload, metadata)
-      if (batchResults.results.length > 0) {
-        this.logger.log(
-          `Fetched ${batchResults.results.length} result${batchResults.results.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
-        )
+    await runWithRequestContext({ integrationId: payload.integrationId }, async () => {
+      this.logger.debug(`Fetching results for integration ${payload.integrationId}`)
+      try {
+        const batchResults = await this.antechV6Service.getBatchResults(payload, metadata)
+        if (batchResults.results.length > 0) {
+          this.logger.log(
+            `Fetched ${batchResults.results.length} result${batchResults.results.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
+          )
 
-        const labAccessionIds = batchResults.results
-          .map((result) => result.accession)
-          .filter((acc): acc is string => acc !== undefined)
+          const labAccessionIds = batchResults.results
+            .map((result) => result.accession)
+            .filter((acc): acc is string => acc !== undefined)
 
-        this.apiClient.emit('external_order_results', {
-          integrationId: payload.integrationId,
-          results: batchResults.results,
-        })
+          this.apiClient.emit('external_order_results', {
+            integrationId: payload.integrationId,
+            results: batchResults.results,
+          })
 
-        this.apiClient.emit('external_results', {
-          integrationId: payload.integrationId,
-          results: batchResults.results,
-        })
+          this.apiClient.emit('external_results', {
+            integrationId: payload.integrationId,
+            results: batchResults.results,
+          })
 
-        await this.antechV6Service.acknowledgeResults({ ids: labAccessionIds }, metadata)
-        this.logger.log(
-          `Acknowledged results ${labAccessionIds.join(',')} for integration ${payload.integrationId}`,
+          await this.antechV6Service.acknowledgeResults({ ids: labAccessionIds }, metadata)
+          this.logger.log(
+            `Acknowledged results ${labAccessionIds.join(',')} for integration ${payload.integrationId}`,
+          )
+        }
+      } catch (error) {
+        this.logger.error(
+          `Error fetching results for integration ${payload.integrationId}: ${error.message}`,
         )
       }
-    } catch (error) {
-      this.logger.error(
-        `Error fetching results for integration ${payload.integrationId}: ${error.message}`,
-      )
-    }
+    })
   }
 }


### PR DESCRIPTION
Part of nominal-systems/dmi-api#302 (PR 3b of the plan: replicates the IDEXX reference implementation, nominal-systems/dmi-engine-idexx-integration#59).

Propagates `integrationId` end-to-end through the Antech V6 integration so `raw_data` events (and therefore `external_requests_v2` documents) can be traced back to the originating integration and practice.

> [!NOTE]
> **Ready for review.** Common 1.3.0 is merged and published (nominal-systems/dmi-engine-common#25). `package.json` now depends on common `^1.3.0` and is bumped to version `0.4.19` (commit `5a5df9a`); the yalc link was removed. CI runs against the published package — `tsc` build and all 84 unit tests pass.
>
> **After approval & merge:** this package is consumed by dmi-engine (it is *not* a standalone service), so the release is a publish, not a deploy. The version bump rides in this PR, so cutting the release only needs a tag (no direct push to `main`):
> ```bash
> git checkout main && git pull
> git tag v0.4.19 && git push origin v0.4.19
> ```
> The tag triggers `publish-package.yml` → `npm publish` of `@nominal-systems/dmi-engine-antech-v6-integration@0.4.19` to the GitHub Package Registry (+ a GitHub Release). The new code only runs once **dmi-engine (PR 4)** bumps its dependency to `0.4.19` and is redeployed.

## Changes

- **`antechV6.module.ts`**: register `IntegrationContextInterceptor` as an `APP_INTERCEPTOR`. Covers the request/reply (MQTT) path — the interceptor extracts `data.integrationId ?? data.payload?.integrationId` from the incoming message and runs the handler inside the request-context scope.
- **`antechV6-orders.processor.ts`** / **`antechV6-results.processor.ts`**: wrap each Bull processor body in `runWithRequestContext({ integrationId: payload.integrationId }, …)`. Covers the polling path. `payload.integrationId` already travels in the job data, so no extra wiring was needed.
- **`package.json`**: bump `@nominal-systems/dmi-engine-common` `^1.2.0` → `^1.3.0` and version `0.4.18` → `0.4.19`.

Both paths converge on the shared `AxiosInterceptor`, which resolves `config.metadata?.integrationId ?? getRequestContext()?.integrationId` and emits it in `raw_data`. `AntechV6ApiInterceptor` only overrides `filter` / `debug` / `extractAccessionIds`, so the base `extract()` (and its `integrationId` resolution) is inherited unchanged. All fields stay optional → backward compatible, deployable in any order.

## Verification

- `npm run build` ✅ · `npm test` ✅ (84/84), against the published common 1.3.0.
- Mirrors the IDEXX reference implementation, where the request/reply path was validated end-to-end locally (documents get `integrationId` + `practiceId`). Polling path covered by the same `runWithRequestContext` → `AxiosInterceptor` mechanism.

## Deploy note

Documents are only *complete* (with `practiceId`) once dmi-api's receiver (nominal-systems/dmi-api#303, commit 2) is also deployed. Engine/api deploy order is interchangeable (optional fields both ways).
