### PR TITLE
Translate out any invalid characters from client name

### DIFF
--- a/src/common/utils/mapper-utils.ts
+++ b/src/common/utils/mapper-utils.ts
@@ -97,6 +97,25 @@ export function mapTestCodeResultStatus(status?: string): TestResultItemStatus {
   }
 }
 
+/**
+ * Sanitizes a name for submission to the Antech V6 API.
+ *
+ * Antech's API spec only allows alphanumeric characters, single quotes and dashes in names
+ * (plus spaces). Accented letters are transliterated to their ASCII base (e.g. `Árbol` -> `Arbol`,
+ * `ñandú` -> `Nandu`) via Unicode NFD normalization, and any remaining disallowed character
+ * (e.g. double quotes) is removed. Resulting double spaces are collapsed and the result is trimmed.
+ *
+ * @see https://github.com/nominal-systems/dmi-api/issues/300
+ */
+export function sanitizeName(name: string): string {
+  return name
+    .normalize('NFD') // decompose accented letters into base letter + diacritic mark
+    .replace(/\p{Diacritic}/gu, '') // drop the diacritic marks, keeping the ASCII base letter
+    .replace(/[^A-Za-z0-9 '-]/g, '') // remove any character Antech does not allow
+    .replace(/\s+/g, ' ') // collapse whitespace introduced by removed characters
+    .trim()
+}
+
 export function generateClinicAccessionId(clinicId: string, pimsId: string): string {
   if (clinicId === undefined) {
     throw new AntechV6ApiException('Error while generating a Clinic Accession ID', 400, {

--- a/src/providers/antechV6-mapper.ts
+++ b/src/providers/antechV6-mapper.ts
@@ -54,6 +54,7 @@ import {
   isOrphanResult,
   mapPatientSex,
   mapTestCodeResultStatus,
+  sanitizeName,
 } from '../common/utils/mapper-utils'
 import { DEFAULT_PET_SPECIES } from '../constants/default-pet-species'
 import { DEFAULT_PET_BREED } from '../constants/default-pet-breed'
@@ -253,8 +254,8 @@ export class AntechV6Mapper {
   private extractClient(client: ClientPayload): AntechV6Client {
     return {
       ClientID: this.getIdFromIdentifier(PimsIdentifiers.ClientID, client.identifier) || client.id,
-      ClientFirstName: client.firstName ? client.firstName.trim() : '',
-      ClientLastName: client.lastName ? client.lastName.trim().slice(0, 20) : '',
+      ClientFirstName: client.firstName ? sanitizeName(client.firstName) : '',
+      ClientLastName: client.lastName ? sanitizeName(client.lastName).slice(0, 20) : '',
       // TODO(gb): extract client address
       // TODO(gb): extract client contact
     }

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -197,6 +197,44 @@ describe('AntechV6Mapper', () => {
         ClientLastName: 'EktesabiKhajooeikerm',
       })
     })
+
+    it('should strip characters not allowed by the Antech API from the client name', () => {
+      const clientPayload = {
+        id: '80ea84f3-86cf-4b56-a6be-2ff6c50d7274',
+        firstName: 'Roger "Doc"',
+        lastName: 'O\'Brien-Smith.',
+        isStaff: false,
+      }
+
+      const result = (mapper as any).extractClient(clientPayload)
+      expect(result.ClientFirstName).toBe('Roger Doc')
+      expect(result.ClientLastName).toBe("O'Brien-Smith")
+    })
+
+    it('should transliterate accented characters in the client name', () => {
+      const clientPayload = {
+        id: '80ea84f3-86cf-4b56-a6be-2ff6c50d7274',
+        firstName: 'Árbol',
+        lastName: 'ñandú',
+        isStaff: false,
+      }
+
+      const result = (mapper as any).extractClient(clientPayload)
+      expect(result.ClientFirstName).toBe('Arbol')
+      expect(result.ClientLastName).toBe('nandu')
+    })
+
+    it('should sanitize the client name before truncating the last name', () => {
+      const clientPayload = {
+        id: '80ea84f3-86cf-4b56-a6be-2ff6c50d7274',
+        firstName: 'Ashkan',
+        lastName: 'Éktesabi"Khajooeikermani',
+        isStaff: false,
+      }
+
+      const result = (mapper as any).extractClient(clientPayload)
+      expect(result.ClientLastName).toBe('EktesabiKhajooeikerm')
+    })
   })
 
   describe('mapAntechV6TestGuide()', () => {


### PR DESCRIPTION
## Summary

Antech's V6 API only allows **alphanumeric characters, spaces, single quotes (`'`) and dashes (`-`)** in names. When a client name contains other characters (e.g. double quotes), Antech rejects the order. Since we can't force every PIMS to follow Antech's restrictions, DMI sanitizes the name before submission.

Cross-repo issue: filed in `dmi-api`, fixed here in the Antech V6 mapper.

## Changes

- Add `sanitizeName()` helper in `common/utils/mapper-utils.ts`:
  1. **Transliterate accents** via Unicode NFD normalization + diacritic removal — keeps the base ASCII letter instead of dropping it (`Árbol` → `Arbol`, `ñandú` → `nandu`, `José` → `Jose`).
  2. **Strip disallowed characters** (`Roger "Doc"` → `Roger Doc`).
  3. Collapse whitespace left behind and `trim()`.
- Apply it to `ClientFirstName` and `ClientLastName` in `extractClient()` (sanitize **before** the 20-char truncation of the last name).
- Unit tests covering double quotes, preserved `'`/`-`, accent transliteration, and sanitize-before-truncate.

## Scope / notes

- **Client name only** for now (per discussion). `PetName` and veterinarian names use the same Antech restriction and could be a follow-up if needed.
- **ASCII strict:** characters that are not letter+diacritic combinations (e.g. `ß`, `Ø`) are not transliterated and get removed. Covers the vast majority of latin-alphabet names.

Closes nominal-systems/dmi-api#300
