### PR TITLE
Preserve result units for non-numeric results

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.3.3",
     "@nestjs/platform-express": "^10.0.0",
-    "@nominal-systems/dmi-engine-common": "^1.4.0",
+    "@nominal-systems/dmi-engine-common": "^1.6.0",
     "axios": "^1.6.7",
     "bull": "^4.12.2",
     "class-transformer": "^0.5.1",

--- a/src/providers/antechV6-mapper.ts
+++ b/src/providers/antechV6-mapper.ts
@@ -220,6 +220,7 @@ export class AntechV6Mapper {
       name: testCodeResult.Test,
       status: mapTestCodeResultStatus(testCodeResult.ResultStatus),
       ...this.extractTestResultValueX(testCodeResult),
+      ...this.extractTestResultUnits(testCodeResult),
       ...this.extractTestResultInterpretation(testCodeResult),
       ...this.extractTestResultReferenceRange(testCodeResult),
       ...this.extractTestResultNotes(testCodeResult),
@@ -427,6 +428,17 @@ export class AntechV6Mapper {
         valueString: testCodeResult.Result || '',
       }
     }
+  }
+
+  private extractTestResultUnits(
+    testCodeResult: AntechV6TestCodeResult,
+  ): Pick<TestResultItem, 'units'> {
+    if (!isNullOrUndefinedOrEmpty(testCodeResult.Unit)) {
+      return { units: testCodeResult.Unit }
+    }
+    // Omitted when Antech sends no Unit → dmi-api delivers it as null,
+    // consistent with how valueQuantity appears as null with no numeric value.
+    return {}
   }
 
   private extractTestResultInterpretation(

--- a/src/providers/antechV6.mapper.spec.ts
+++ b/src/providers/antechV6.mapper.spec.ts
@@ -831,6 +831,7 @@ describe('AntechV6Mapper', () => {
           value: 3.3,
           units: 'g/dL',
         },
+        units: 'g/dL',
         referenceRange: [
           {
             type: ReferenceRangeType.NORMAL,
@@ -865,6 +866,7 @@ describe('AntechV6Mapper', () => {
           value: 128,
           units: 'IU/L',
         },
+        units: 'IU/L',
         interpretation: {
           code: TestResultItemInterpretationCode.HIGH,
           text: 'H',
@@ -927,6 +929,7 @@ describe('AntechV6Mapper', () => {
           value: 13.8,
           units: 'UG/dL',
         },
+        units: 'UG/dL',
         referenceRange: [
           {
             type: ReferenceRangeType.NORMAL,
@@ -935,6 +938,63 @@ describe('AntechV6Mapper', () => {
           },
         ],
       })
+    })
+    it('should preserve the unit for non-numeric (comparator) results', () => {
+      const testCodeResult = {
+        TestCodeID: '51001',
+        TestCodeResultID: '7533583999',
+        Result: '< 20',
+        Range: '0-229',
+        TestCodeExtID: '51001',
+        Test: 'ALP',
+        Unit: 'U/l',
+        UnitCodeID: '800599099',
+        ReportComments: [],
+      }
+      expect(mapper.mapAntechV6TestCodeResult(testCodeResult, 0)).toEqual({
+        seq: 0,
+        code: '51001',
+        name: 'ALP',
+        status: 'DONE',
+        valueString: '< 20',
+        units: 'U/l',
+        referenceRange: [
+          {
+            type: ReferenceRangeType.NORMAL,
+            text: '0-229',
+            low: 0,
+            high: 229,
+          },
+        ],
+      })
+    })
+    it('should omit units when Antech sends no Unit', () => {
+      const testCodeResult = {
+        TestCodeID: '51100',
+        TestCodeResultID: '7533584000',
+        Result: '1.2',
+        Range: '',
+        TestCodeExtID: '51100',
+        Test: 'Na/K',
+        UnitCodeID: '800599100',
+        ReportComments: [],
+      }
+      const result = mapper.mapAntechV6TestCodeResult(testCodeResult, 0)
+      expect(result).not.toHaveProperty('units')
+    })
+    it('should omit units when Antech sends an empty Unit', () => {
+      const testCodeResult = {
+        TestCodeID: '51101',
+        TestCodeResultID: '7533584001',
+        Result: '****',
+        TestCodeExtID: '51101',
+        Test: 'Est Osm',
+        Unit: '',
+        UnitCodeID: '800599101',
+        ReportComments: [],
+      }
+      const result = mapper.mapAntechV6TestCodeResult(testCodeResult, 0)
+      expect(result).not.toHaveProperty('units')
     })
   })
 


### PR DESCRIPTION
Closes #71

## What

Populate the new observation-level `units` field from Antech's `Unit`, regardless of which value branch (`valueQuantity` vs `valueString`) the result takes, so units are no longer silently dropped for non-numeric results (`< 20`, `****`, `-OR`, …).

## Background

`extractTestResultValueX()` is an exclusive if/else: the numeric branch carries `Unit` into `valueQuantity.units`, the string branch returns `valueString` only and discards the unit. In the UAT accession `140130-VOY-908884130`, 17 observations lost a unit Antech actually sent (ALP `< 20 U/l`, CK `< 10 U/l`, …). The clearest case is Total Bilirubin, which appears twice in the same study under code `51003`: `212` → delivered with `umol/l`, `< 3` → unit dropped.

The gap is structural in the shared contract — `TestResultItem` had no place for a unit not attached to a numeric quantity. That field was added in dmi-engine-common (`units?: string`).

## Approach

- New `extractTestResultUnits()` helper, spread into `mapAntechV6TestCodeResult()` outside the value if/else.
- Follows the established spread-`{}` idiom: when `Unit` is absent or empty (`isNullOrUndefinedOrEmpty`), the field is **omitted** — not `units: ""` and not `units: null`. Omitted at the mapper/MQTT level → `dmi-api` delivers it as `null` to the PIMS, consistent with how `valueQuantity` appears as `null` when there is no numeric value. This matches the decision recorded in the issue.
- Covers the ratio/calculated rows (Na/K, Alb/Glob, Sodium, …) where Antech sends no `Unit` at all, and the `Unit: ""` case — both fall into the omit branch.

`valueString` is untouched — `< 20` keeps its "less than" semantics. For numeric items the unit is intentionally duplicated (`valueQuantity.units` **and** `units`); removing `valueQuantity.units` would break current consumers and can be deprecated later.

## Safety

Additive and optional. Numeric items keep `valueQuantity.units` exactly as before; the only new output is the top-level `units`.

## Tests

Mapper specs updated: existing numeric expectations now assert the duplicated `units`; new cases cover (a) a non-numeric comparator result preserving its unit (ALP `< 20` → `units: "U/l"`), (b) omission when no `Unit` is sent, and (c) omission when `Unit` is empty. Full suite: 37/37 passing. `tsc` build and `eslint` clean.

## Caveats

Depends on **dmi-engine-common#28** (`units?` on `TestResultItem`) being released as `1.6.0`; this PR bumps the dependency to `^1.6.0`. Historical results stay without units unless reprocessed.
