### PR TITLE
Skip TRF downloads for in-house (point-of-care) orders

### DIFF
--- a/src/services/antechV6.service.spec.ts
+++ b/src/services/antechV6.service.spec.ts
@@ -373,6 +373,127 @@ describe('AntechV6Service', () => {
       expect(antechV6ApiServiceMock.getOrderTrf).not.toHaveBeenCalled()
       expect(orders[0].manifest).toBeUndefined()
     })
+    it('should skip the TRF when every test is point-of-care per the test guide', async () => {
+      antechV6ApiServiceMock.getTestGuide.mockResolvedValue({
+        TotalCount: 2,
+        LabResults: [{ Code: 'HDC-1' }, { Code: 'HDC-29' }],
+      })
+      antechV6ApiServiceMock.getOrderStatus.mockResolvedValue({
+        LabOrders: [
+          {
+            ClinicAccessionID: 'ACC200',
+            LabTests: [
+              {
+                CodeType: 'U',
+                CodeID: 20001,
+                Mnemonic: 'HDC-1',
+                DisplayName: 'Internal Organ Function',
+                Price: 0,
+              },
+            ],
+          },
+        ],
+      })
+      antechV6ApiServiceMock.getResultStatus.mockResolvedValue({ LabResults: [] })
+
+      const orders: Order[] = await service.getBatchOrders(payloadMock, metadataMock)
+
+      expect(antechV6ApiServiceMock.getOrderTrf).not.toHaveBeenCalled()
+      expect(orders[0].manifest).toBeUndefined()
+    })
+    it('should fetch the TRF when an order mixes point-of-care and reference lab tests', async () => {
+      antechV6ApiServiceMock.getTestGuide.mockResolvedValue({
+        TotalCount: 1,
+        LabResults: [{ Code: 'HDC-1' }],
+      })
+      antechV6ApiServiceMock.getOrderStatus.mockResolvedValue({
+        LabOrders: [
+          {
+            ClinicAccessionID: 'ACC201',
+            LabTests: [
+              {
+                CodeType: 'U',
+                CodeID: 20001,
+                Mnemonic: 'HDC-1',
+                DisplayName: 'Internal Organ Function',
+                Price: 0,
+              },
+              {
+                CodeType: 'U',
+                CodeID: 30001,
+                Mnemonic: 'BANT805',
+                DisplayName: 'Chemistry Panel',
+                Price: 45.5,
+              },
+            ],
+          },
+        ],
+      })
+      antechV6ApiServiceMock.getResultStatus.mockResolvedValue({ LabResults: [] })
+
+      await service.getBatchOrders(payloadMock, metadataMock)
+
+      expect(antechV6ApiServiceMock.getOrderTrf).toHaveBeenCalled()
+    })
+    it('should fall back to the configured IhdMnemonic when the test guide is unavailable', async () => {
+      antechV6ApiServiceMock.getTestGuide.mockRejectedValue(new Error('test guide unavailable'))
+      const metadataWithSkip = {
+        ...metadataMock,
+        providerConfiguration: {
+          ...metadataMock.providerConfiguration,
+          IhdMnemonic: ['HHEM-1'],
+        },
+      }
+      antechV6ApiServiceMock.getOrderStatus.mockResolvedValue({
+        LabOrders: [
+          {
+            ClinicAccessionID: 'ACC202',
+            LabTests: [
+              {
+                CodeType: 'U',
+                CodeID: 10001,
+                Mnemonic: 'HHEM-1',
+                DisplayName: 'In-house Hematology',
+                Price: 0,
+              },
+            ],
+          },
+        ],
+      })
+      antechV6ApiServiceMock.getResultStatus.mockResolvedValue({ LabResults: [] })
+
+      await service.getBatchOrders(payloadMock, metadataWithSkip)
+
+      expect(antechV6ApiServiceMock.getOrderTrf).not.toHaveBeenCalled()
+    })
+    it('should fetch the point-of-care test guide once across batches', async () => {
+      antechV6ApiServiceMock.getTestGuide.mockResolvedValue({
+        TotalCount: 1,
+        LabResults: [{ Code: 'HDC-1' }],
+      })
+      antechV6ApiServiceMock.getOrderStatus.mockResolvedValue({
+        LabOrders: [
+          {
+            ClinicAccessionID: 'ACC203',
+            LabTests: [
+              {
+                CodeType: 'U',
+                CodeID: 20001,
+                Mnemonic: 'HDC-1',
+                DisplayName: 'Internal Organ Function',
+                Price: 0,
+              },
+            ],
+          },
+        ],
+      })
+      antechV6ApiServiceMock.getResultStatus.mockResolvedValue({ LabResults: [] })
+
+      await service.getBatchOrders(payloadMock, metadataMock)
+      await service.getBatchOrders(payloadMock, metadataMock)
+
+      expect(antechV6ApiServiceMock.getTestGuide).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('createOrder()', () => {

--- a/src/services/antechV6.service.ts
+++ b/src/services/antechV6.service.ts
@@ -41,6 +41,9 @@ import { AntechV6ApiException } from '../common/exceptions/antechV6-api.exceptio
 export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
   private readonly logger = new Logger(AntechV6Service.name)
 
+  private static readonly POC_CACHE_TTL_MS = 60 * 60 * 1000
+  private readonly pocCodeCache = new Map<string, { codes: Set<string>; expiresAt: number }>()
+
   constructor(
     private readonly antechV6Api: AntechV6ApiService,
     private readonly antechV6Mapper: AntechV6Mapper,
@@ -138,6 +141,12 @@ export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
       false,
     )
 
+    // In-house (point-of-care) orders have no TRF. Antech's test guide is the source of truth for
+    // which codes are POC; the IhdMnemonic configuration is kept as a fallback and an override.
+    const pocCodes = await this.getPocCodes(metadata.providerConfiguration.baseUrl, credentials)
+    const isInHouse = (mn: string): boolean =>
+      pocCodes?.has(mn) === true || IhdMnemonic.includes(mn)
+
     const orders: Order[] = []
     for (const orderStatus of orderStatusResponse.LabOrders) {
       const resultStatusResponse = await this.antechV6Api.getResultStatus(
@@ -154,9 +163,13 @@ export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
             )
           : (this.antechV6Mapper.mapAntechV6OrderStatus(orderStatus) as unknown as Order)
 
-      const orderMnemonics = [...(orderStatus.LabTests || []).map((t) => t.Mnemonic)]
+      const orderMnemonics = (orderStatus.LabTests || []).map((t) => t.Mnemonic)
 
-      if (!orderMnemonics.some((mn) => IhdMnemonic.includes(mn))) {
+      // A TRF accompanies the physical sample sent to the reference lab, so one exists only if at
+      // least one test on the order is not in-house. Skip the call when every test is in-house.
+      const inHouseOnly = orderMnemonics.length > 0 && orderMnemonics.every(isInHouse)
+
+      if (!inHouseOnly) {
         const manifest: Attachment | undefined = await this.antechV6Api.getOrderTrf(
           metadata.providerConfiguration.baseUrl,
           credentials,
@@ -414,21 +427,47 @@ export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
       return false
     }
 
-    try {
-      const pocTests = await this.antechV6Api.getTestGuide(
-        metadata.providerConfiguration.baseUrl,
-        credentials,
-        { POC_FLAG: 'Y' },
-      )
+    const pocCodes = await this.getPocCodes(metadata.providerConfiguration.baseUrl, credentials)
+    if (pocCodes == null) {
+      // Test guide unavailable: keep the existing conservative default of the pre-order flow.
+      return false
+    }
 
-      const pocCodes = new Set((pocTests.LabResults || []).map((test) => test.Code))
-      return pocCodes.size > 0 && orderCodes.every((code) => pocCodes.has(code))
+    return orderCodes.every((code) => pocCodes.has(code))
+  }
+
+  /**
+   * Point-of-care (in-house) test codes for a clinic, per Antech's test guide (POC_FLAG=Y).
+   * Cached because the guide is a 2500-row fetch preceded by a login, and callers reach for it on
+   * every polled batch and every auto-submitted order.
+   * Returns undefined when the guide is unavailable so callers can fall back to configuration.
+   */
+  private async getPocCodes(
+    baseUrl: string,
+    credentials: AntechV6UserCredentials,
+  ): Promise<Set<string> | undefined> {
+    const cacheKey = `${baseUrl}|${credentials.ClinicID}`
+    const cached = this.pocCodeCache.get(cacheKey)
+    if (cached != null && cached.expiresAt > Date.now()) {
+      return cached.codes
+    }
+
+    try {
+      const pocTests = await this.antechV6Api.getTestGuide(baseUrl, credentials, { POC_FLAG: 'Y' })
+      const codes = new Set((pocTests.LabResults || []).map((test) => test.Code))
+      if (codes.size === 0) {
+        return undefined
+      }
+
+      this.pocCodeCache.set(cacheKey, {
+        codes,
+        expiresAt: Date.now() + AntechV6Service.POC_CACHE_TTL_MS,
+      })
+      return codes
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      this.logger.warn(
-        `Failed to fetch POC tests from test guide; defaulting to pre-order flow. Error: ${message}`,
-      )
-      return false
+      this.logger.warn(`Failed to fetch POC tests from test guide: ${message}`)
+      return undefined
     }
   }
 }


### PR DESCRIPTION
Fixes #74

## Problem

`getBatchOrders()` decided whether to download a TRF by testing order mnemonics against `providerConfiguration.IhdMnemonic` — a hand-maintained list which in production held a single entry, `HHEM-1`.

On **2026-08-03 21:07 UTC** Antech began accepting 18 new point-of-care test codes (`HDC-1/7/8/9/10/12–19/29`, `HEI-2`, `HEI-17`, `HTR-1`, `HTR-14`). Every one reports `POC_FLAG=Y` in Antech's test guide, but none were on the configured list, so DMI requested a TRF for orders that cannot have one and Antech responded `400`.

Measured in `log-voyager-prod-cus`, pod `dmiengineapi`:

| Day (UTC) | TRF OK | TRF fail | Fail % |
|---|---|---|---|
| Jul 23 – Aug 2 | 3.2k–6.7k | 0–5 | 0.03–0.15% |
| Aug 3 | 6967 | 13 | 0.19% |
| **Aug 4** | 6646 | **383** | **5.45%** |
| **Aug 5** | 6830 | **266** | **3.75%** |

685 distinct orders failed, none ever succeeded on a later poll — a permanent property of those orders, not a transient Antech fault. No deploy was involved: the pods have been running since Jul 22.

## Fix

Derive the in-house test set from Antech's test guide (`POC_FLAG=Y`) rather than from static configuration. This is authoritative and the engine **already** relies on it — `orderContainsOnlyPocTests()` uses exactly this call on the order-placement path. The polling path was simply discarding that knowledge.

- `IhdMnemonic` is retained as a fallback and an override, so existing configuration keeps working.
- If the test guide is unavailable, `getPocCodes()` returns `undefined` and behaviour falls back to today's. Fails open — no new hard dependency.
- **`some()` → `every()`**: a TRF accompanies the physical sample sent to the reference lab, so one exists whenever at least one test on the order is *not* in-house. The previous `some()` over-skipped mixed orders. Production orders are single-code today, so this is behaviour-neutral now and correct later.
- Results are **cached per `baseUrl`+clinic for an hour**. The guide is a 2500-row fetch preceded by a login; this also removes an uncached fetch from every auto-submitted order (~17k/day in production).

## Testing

`npx jest` — 94 passed, 6 suites. Four new cases in `antechV6.service.spec.ts`:

- skips the TRF when every test is point-of-care per the test guide
- fetches the TRF when an order mixes point-of-care and reference lab tests
- falls back to configured `IhdMnemonic` when the test guide is unavailable
- fetches the test guide once across batches (cache)

All pre-existing tests pass untouched. `tsc --noEmit` reports four errors in `antechV6.module.ts`, `antechV6.controller.ts` and the two processors — these are **pre-existing on `main`** (verified by stashing) and stem from a stale local `dmi-engine-common`; none are in the files changed here. ESLint is clean.

## Deploying

Antech V6 runs bundled inside the `dmiengineapi` pod, so this needs a publish plus a `package.json` bump in `dmi-engine` (`^0.4.20` → `^0.4.21`) to reach production.

**Immediate mitigation available without a deploy:** add the 18 codes to `IhdMnemonic` in provider configuration. That stops the bleeding today; this PR stops it recurring the next time Antech adds an in-house test.

## Out of scope

The engine still registers `HttpModule.register({})` with no HTTP timeout ([`antech-v6-api.module.ts:14`](../blob/main/src/antechV6-api/antech-v6-api.module.ts#L14)) — a standing finding from Jason Storey's July review. It is deliberately **not** addressed here: no hangs are occurring (zero stalled Bull jobs and zero timeout signatures across 14 days), and changing timeout behaviour for every call in the engine deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
