### PR TITLE
Fall back to IhdMnemonic when POC test guide lookup fails

### DIFF
--- a/src/services/antechV6.service.spec.ts
+++ b/src/services/antechV6.service.spec.ts
@@ -623,12 +623,77 @@ describe('AntechV6Service', () => {
       )
     })
 
-    it('places a pre-order when autoSubmitOrder is true and POC lookup fails', async () => {
+    it('falls back to IhdMnemonic and places an order when POC lookup fails and all codes are in IhdMnemonic', async () => {
+      antechV6ApiServiceMock.getTestGuide.mockRejectedValueOnce(new Error('request timeout'))
+      antechV6ApiServiceMock.placeOrder.mockResolvedValue({
+        payload: 'ok',
+        status: 200,
+        message: 'success',
+        isSuccess: true,
+        requestId: 'r1',
+        Token: 'tok',
+      })
+      const resp: OrderCreatedResponse = await service.createOrder(createOrderPayload, {
+        ...metadataMock,
+        autoSubmitOrder: true,
+        providerConfiguration: {
+          ...metadataMock.providerConfiguration,
+          IhdMnemonic: ['SA804', 'HHEM-1'],
+        },
+        integrationOptions: {
+          ...metadataMock.integrationOptions,
+          autoSubmitEnabled: true,
+        },
+      } as any)
+
+      expect(antechV6ApiServiceMock.placeOrder).toHaveBeenCalled()
+      expect(antechV6ApiServiceMock.placePreOrder).not.toHaveBeenCalled()
+      expect(resp).toEqual(
+        expect.objectContaining({
+          requisitionId: 'REQ123',
+          externalId: 'REQ123',
+          status: OrderStatus.SUBMITTED,
+        }),
+      )
+    })
+
+    it('places a pre-order when POC lookup fails and IhdMnemonic is empty', async () => {
       antechV6ApiServiceMock.getTestGuide.mockRejectedValueOnce(new Error('request timeout'))
       antechV6ApiServiceMock.placePreOrder.mockResolvedValue({ Value: 'ok', Token: 'tok' })
       const resp: OrderCreatedResponse = await service.createOrder(createOrderPayload, {
         ...metadataMock,
         autoSubmitOrder: true,
+        providerConfiguration: {
+          ...metadataMock.providerConfiguration,
+          IhdMnemonic: [],
+        },
+        integrationOptions: {
+          ...metadataMock.integrationOptions,
+          autoSubmitEnabled: true,
+        },
+      } as any)
+
+      expect(antechV6ApiServiceMock.placeOrder).not.toHaveBeenCalled()
+      expect(antechV6ApiServiceMock.placePreOrder).toHaveBeenCalled()
+      expect(resp).toEqual(
+        expect.objectContaining({
+          requisitionId: 'REQ123',
+          externalId: 'REQ123',
+          status: OrderStatus.WAITING_FOR_INPUT,
+        }),
+      )
+    })
+
+    it('places a pre-order when POC lookup fails and order codes are not all in IhdMnemonic', async () => {
+      antechV6ApiServiceMock.getTestGuide.mockRejectedValueOnce(new Error('request timeout'))
+      antechV6ApiServiceMock.placePreOrder.mockResolvedValue({ Value: 'ok', Token: 'tok' })
+      const resp: OrderCreatedResponse = await service.createOrder(createOrderPayload, {
+        ...metadataMock,
+        autoSubmitOrder: true,
+        providerConfiguration: {
+          ...metadataMock.providerConfiguration,
+          IhdMnemonic: ['HHEM-1'],
+        },
         integrationOptions: {
           ...metadataMock.integrationOptions,
           autoSubmitEnabled: true,

--- a/src/services/antechV6.service.ts
+++ b/src/services/antechV6.service.ts
@@ -429,8 +429,8 @@ export class AntechV6Service extends BaseProviderService<AntechV6MessageData> {
 
     const pocCodes = await this.getPocCodes(metadata.providerConfiguration.baseUrl, credentials)
     if (pocCodes == null) {
-      // Test guide unavailable: keep the existing conservative default of the pre-order flow.
-      return false
+      const { IhdMnemonic = [] } = metadata.providerConfiguration
+      return IhdMnemonic.length > 0 && orderCodes.every((code) => IhdMnemonic.includes(code))
     }
 
     return orderCodes.every((code) => pocCodes.has(code))


### PR DESCRIPTION
Fixes #76

## What

When the Antech test guide lookup (`GET /Tests/v6?POC_FLAG=Y`) fails, `orderContainsOnlyPocTests()` now falls back to the configured `IhdMnemonic` list instead of unconditionally returning `false` and routing the order through `PreOrderPlacement`.

## Background

Since 2026-08-11, 7 PROD clinics receive `400` on every test guide call. Because the ordering path had no fallback, every order from those clinics — including in-house tests like `HHEM-1` (CBC) — degraded to `WAITING_FOR_INPUT`, requiring manual submission in the Antech UI (~149 orders/day affected).

#75 already added the `IhdMnemonic` fallback for the TRF path in `getBatchOrders()` and extracted `getPocCodes()` with a 1-hour cache. This PR extends the same fallback to the ordering path, which #75 deliberately left on the conservative default.

## Approach

Two-line change in `orderContainsOnlyPocTests()`: when `getPocCodes()` returns `undefined` (guide unavailable), check `IhdMnemonic` from the provider configuration instead of returning `false`. The test guide remains the primary source of truth — `IhdMnemonic` is only consulted on lookup failure.

## Safety

`IhdMnemonic` is a global list on the provider configuration (one `antech-v6` config for all clinics), while the test guide is per-clinic. The fallback can over-approximate for clinics that lack specific analyzers. However, Antech's `/Order` endpoint rejects non-POC codes, so the worst case is a server-side rejection rather than a silently mis-routed order.

## Tests

`npx jest` — 96 passed, 6 suites. Replaced the existing fallback test and added two new cases:

- Guide fails + all order codes in `IhdMnemonic` → `placeOrder` (auto-submit)
- Guide fails + `IhdMnemonic` empty → `placePreOrder` (conservative default preserved)
- Guide fails + order codes not all in `IhdMnemonic` → `placePreOrder` (mixed order)