### PR TITLE
0.4.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nominal-systems/dmi-engine-antech-v6-integration",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nominal-systems/dmi-engine-antech-v6-integration",
-      "version": "0.4.21",
+      "version": "0.4.22",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nominal-systems/dmi-engine-antech-v6-integration",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "description": "",
   "author": "",
   "license": "UNLICENSED",


### PR DESCRIPTION
Version bump for release.

Publishes the `IhdMnemonic` fallback for failed POC test guide lookups from #77 as `0.4.22` (patch).

Once merged, `v0.4.22` is tagged from `main` so the run is titled `0.4.22`, consistent with previous releases.